### PR TITLE
Adapt code to use cryptonite package

### DIFF
--- a/lib/Data/Locator/Common.hs
+++ b/lib/Data/Locator/Common.hs
@@ -28,8 +28,8 @@ module Data.Locator.Common
 
 import Prelude hiding (toInteger)
 
-import Crypto.Hash.SHA1 as Crypto
-import qualified Data.ByteString as B
+import Crypto.Hash as Crypto
+import qualified Data.ByteArray as B
 import qualified Data.ByteString.Char8 as S
 import Data.List (mapAccumL)
 import Data.Set (Set)
@@ -133,6 +133,6 @@ digest ws =
   where
     i  = concatToInteger h
     h  = B.unpack h'
-    h' = Crypto.hash x'
+    h' = Crypto.hash x' :: Crypto.Digest Crypto.SHA1
     x' = S.pack ws
 

--- a/lib/Data/Locator/Hashes.hs
+++ b/lib/Data/Locator/Hashes.hs
@@ -23,9 +23,9 @@ module Data.Locator.Hashes (
 
 import Prelude hiding (toInteger)
 
-import Crypto.Hash.SHA1 as Crypto
+import Crypto.Hash as Crypto
+import qualified Data.ByteArray as B
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as S
 import Data.Char (chr, isDigit, isLower, isUpper, ord)
 import Data.Word
@@ -91,7 +91,7 @@ digest ws =
   where
     i  = concatToInteger h
     h  = B.unpack h'
-    h' = Crypto.hash x'
+    h' = Crypto.hash x' :: Crypto.Digest Crypto.SHA1
     x' = S.pack ws
 
 

--- a/locators.cabal
+++ b/locators.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.24
 name:                locators
-version:             0.3.0.2
+version:             0.3.0.3
 synopsis:            Human exchangable identifiers and locators
 license:             MIT
 license-file:        LICENSE
@@ -24,9 +24,10 @@ library
   default-language:  Haskell2010
 
   build-depends:     base >= 4 && <5,
+                     memory,
                      bytestring,
                      containers,
-                     cryptohash
+                     cryptonite
 
   hs-source-dirs:    lib
   include-dirs:      .
@@ -59,7 +60,7 @@ test-suite           check
                      QuickCheck,
                      bytestring,
                      containers,
-                     cryptohash,
+                     cryptonite,
                      locators
 
   hs-source-dirs:    tests

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-16.5
+resolver: lts-16.7


### PR DESCRIPTION
Long overdue: port this code to stop using the now deprecated **cryptohash** and replace it with **cryptonite** (which the former has been made just a wrapper of).